### PR TITLE
Check for resultBytes being nil, instead of result

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -2,13 +2,14 @@ package conduit
 
 import (
 	"encoding/json"
-	"github.com/karlseguin/typed"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/karlseguin/typed"
 )
 
 // containsString checks whether s contains e.
@@ -81,7 +82,7 @@ func call(endpointURL string, params interface{}, result interface{}) error {
 		return err
 	}
 
-	if result != nil {
+	if resultBytes != nil {
 		if err = json.Unmarshal(resultBytes, &result); err != nil {
 			return err
 		}

--- a/utils.go
+++ b/utils.go
@@ -82,7 +82,7 @@ func call(endpointURL string, params interface{}, result interface{}) error {
 		return err
 	}
 
-	if resultBytes != nil {
+	if result != nil && resultBytes != nil {
 		if err = json.Unmarshal(resultBytes, &result); err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes a JSON decoding error when API doesn't respond with JSON (as is the case in the prototype Harbormaster Phabricator application)
