### PR TITLE
Protecting long numbers while JSON Unmarshal

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -16,13 +16,6 @@ func init() {
 	testCert = os.Getenv("GOCONDUIT_CERT")
 }
 
-type conduitCapabilitiesResponse struct {
-	Authentication []string `json:"authentication"`
-	Signatures     []string `json:"signatures"`
-	Input          []string `json:"input"`
-	Output         []string `json:"output"`
-}
-
 func TestCall(t *testing.T) {
 	conn, err := Dial(testHost)
 	if err != nil {

--- a/connect_test.go
+++ b/connect_test.go
@@ -78,7 +78,7 @@ func TestConnect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if conn.host != "https://code.interworks.com" {
+	if conn.host != testHost {
 		t.Error("bad host")
 	}
 


### PR DESCRIPTION
Ran into connection issue after upgrading Phabricator. Looks updated version of Phabricator is giving long number for ConnectionID. When doing JSON unmarshal, it gets converted into floating point number http://stackoverflow.com/questions/22343083/json-marshaling-with-long-numbers-in-golang-gives-floating-point-number

Patch to prevent it from happening. 